### PR TITLE
createArtificialRoot = true

### DIFF
--- a/src/ifcx-core/workflows.ts
+++ b/src/ifcx-core/workflows.ts
@@ -21,7 +21,7 @@ function ToInputNodes(data: IfcxNode[])
 
 
 // TODO: cleanup options by creating better API
-export function LoadIfcxFile(file: IfcxFile, checkSchemas: boolean = true, createArtificialRoot: boolean = false)
+export function LoadIfcxFile(file: IfcxFile, checkSchemas: boolean = true, createArtificialRoot: boolean = true)
 {
     let inputNodes = ToInputNodes(file.data);
     let compositionNodes = FlattenCompositionInput(inputNodes);


### PR DESCRIPTION
I think this should be the default. That's how it has always worked

![afbeelding](https://github.com/user-attachments/assets/ebedf160-90b9-4a46-b315-21ff9ae18f51)
