### PR TITLE
Schema optional reference

### DIFF
--- a/schema/ifcx.tsp
+++ b/schema/ifcx.tsp
@@ -35,7 +35,7 @@ enum DataType
     Enum: "Enum",
     Array: "Array",
     Object: "Object",
-    Relation: "Relation",
+    Reference: "Reference",
     Blob: "Blob"
 }
 
@@ -57,21 +57,16 @@ model ObjectRestrictions
     values: Record<IfcxValueDescription>;
 }
 
-model RelationRestrictions
-{
-    type: string;
-}
-
 model IfcxValueDescription
 {
     dataType: DataType;
+    optional?: boolean;
     inherits?: string[];
     quantityKind?: QuantityKind;
 
     enumRestrictions?: EnumRestrictions;
     arrayRestrictions?: ArrayRestrictions;
     objectRestrictions?: ObjectRestrictions;
-    relationRestrictions?: RelationRestrictions;
 }
 
 model IfcxSchema

--- a/schema/out/@typespec/openapi3/openapi.yaml
+++ b/schema/out/@typespec/openapi3/openapi.yaml
@@ -28,7 +28,7 @@ components:
         - Enum
         - Array
         - Object
-        - Relation
+        - Reference
         - Blob
     EnumRestrictions:
       type: object
@@ -113,6 +113,8 @@ components:
       properties:
         dataType:
           $ref: '#/components/schemas/DataType'
+        optional:
+          type: boolean
         inherits:
           type: array
           items:
@@ -125,8 +127,6 @@ components:
           $ref: '#/components/schemas/ArrayRestrictions'
         objectRestrictions:
           $ref: '#/components/schemas/ObjectRestrictions'
-        relationRestrictions:
-          $ref: '#/components/schemas/RelationRestrictions'
     ImportNode:
       type: object
       required:
@@ -162,13 +162,6 @@ components:
         - Energy
         - Power
         - Volume
-    RelationRestrictions:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
     code:
       type: string
       pattern: </[A-Za-z0-9]+>

--- a/schema/out/ts/ifcx.d.ts
+++ b/schema/out/ts/ifcx.d.ts
@@ -13,7 +13,7 @@ export interface components {
             value: components["schemas"]["IfcxValueDescription"];
         };
         /** @enum {string} */
-        DataType: "Real" | "Boolean" | "Integer" | "String" | "DateTime" | "Enum" | "Array" | "Object" | "Relation" | "Blob";
+        DataType: "Real" | "Boolean" | "Integer" | "String" | "DateTime" | "Enum" | "Array" | "Object" | "Reference" | "Blob";
         EnumRestrictions: {
             options: string[];
         };
@@ -49,12 +49,12 @@ export interface components {
         };
         IfcxValueDescription: {
             dataType: components["schemas"]["DataType"];
+            optional?: boolean;
             inherits?: string[];
             quantityKind?: components["schemas"]["QuantityKind"];
             enumRestrictions?: components["schemas"]["EnumRestrictions"];
             arrayRestrictions?: components["schemas"]["ArrayRestrictions"];
             objectRestrictions?: components["schemas"]["ObjectRestrictions"];
-            relationRestrictions?: components["schemas"]["RelationRestrictions"];
         };
         ImportNode: {
             uri: string;
@@ -67,9 +67,6 @@ export interface components {
         };
         /** @enum {string} */
         QuantityKind: "Plane angle" | "Thermodynamic temperature" | "Electric current" | "Time" | "Frequency" | "Mass" | "Length" | "Linear velocity" | "Force" | "Pressure" | "Area" | "Energy" | "Power" | "Volume";
-        RelationRestrictions: {
-            type: string;
-        };
         code: string;
         path: string;
     };

--- a/src/ifcx-core/schema/schema-validation.ts
+++ b/src/ifcx-core/schema/schema-validation.ts
@@ -67,7 +67,7 @@ function ValidateAttributeValue(desc: IfcxValueDescription, value: any, path: st
             throw new SchemaValidationError(`Expected "${value}" to be of type real`);
         }
     }
-    else if (desc.dataType === "Relation")
+    else if (desc.dataType === "Reference")
     {
         if (typeof value !== "string")
         {

--- a/src/ifcx-core/schema/schema-validation.ts
+++ b/src/ifcx-core/schema/schema-validation.ts
@@ -8,6 +8,12 @@ export class SchemaValidationError extends Error
 
 function ValidateAttributeValue(desc: IfcxValueDescription, value: any, path: string, schemas: {[key: string]: IfcxSchema})
 {
+    if (desc.optional && value === null)
+    {
+        // we're good
+        return;
+    }
+
     if (desc.inherits)
     {
         desc.inherits.forEach((inheritedSchemaID) => {

--- a/src/test/example-file.ts
+++ b/src/test/example-file.ts
@@ -72,6 +72,26 @@ export function ExampleFile(attribute: string = "example::string", value: any = 
                     }
                 }
             },
+            "example::optional_object": {
+                uri: "http://www.example.com/object",
+                value: {
+                    dataType: "Object",
+                    objectRestrictions: {
+                        values: {
+                            "val1": {
+                                dataType: "String",
+                                optional: true
+                            },
+                            "val2": {
+                                dataType: "Enum",
+                                enumRestrictions: {
+                                    options: ["a", "b", "c"]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "example::array": {
                 uri: "http://www.example.com/array",
                 value: {

--- a/src/test/schema-test.ts
+++ b/src/test/schema-test.ts
@@ -29,7 +29,7 @@ describe("schemas", () => {
         
         expect(() => LoadIfcxFile(ExampleFileWithSchema("Integer", null))).to.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFileWithSchema("Real", null))).to.throw(SchemaValidationError);
-        expect(() => LoadIfcxFile(ExampleFileWithSchema("Relation", null))).to.throw(SchemaValidationError);
+        expect(() => LoadIfcxFile(ExampleFileWithSchema("Reference", null))).to.throw(SchemaValidationError);
 
         expect(() => LoadIfcxFile(ExampleFileWithSchema("Object", false))).to.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::object", [null]))).to.throw(SchemaValidationError);

--- a/src/test/schema-test.ts
+++ b/src/test/schema-test.ts
@@ -10,7 +10,7 @@ describe("schemas", () => {
         let openAPISchema = SchemasToOpenAPI(ExampleFile());
 
         // TODO
-        expect(openAPISchema.length).to.equal(720);
+        expect(openAPISchema.length).to.equal(926);
     });
 
     it("throws error if attribute references unknown schema ID", () => {
@@ -38,6 +38,8 @@ describe("schemas", () => {
         expect(() => LoadIfcxFile(ExampleFile("example::object", {val1: false, val2: "a"}))).to.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::object", {val1: "", val2: "a"}))).to.not.throw(SchemaValidationError);
         
+        expect(() => LoadIfcxFile(ExampleFile("example::optional_object", {val1: null, val2: "a"}))).to.not.throw(SchemaValidationError);
+
         expect(() => LoadIfcxFile(ExampleFileWithSchema("Array", null))).to.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::array", [false]))).to.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::array", ["d"]))).to.throw(SchemaValidationError);

--- a/src/test/schema-test.ts
+++ b/src/test/schema-test.ts
@@ -38,7 +38,9 @@ describe("schemas", () => {
         expect(() => LoadIfcxFile(ExampleFile("example::object", {val1: false, val2: "a"}))).to.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::object", {val1: "", val2: "a"}))).to.not.throw(SchemaValidationError);
         
+        expect(() => LoadIfcxFile(ExampleFile("example::optional_object", {val1: "", val2: "a"}))).to.not.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::optional_object", {val1: null, val2: "a"}))).to.not.throw(SchemaValidationError);
+        expect(() => LoadIfcxFile(ExampleFile("example::optional_object", {val1: null, val2: null}))).to.throw(SchemaValidationError);
 
         expect(() => LoadIfcxFile(ExampleFileWithSchema("Array", null))).to.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::array", [false]))).to.throw(SchemaValidationError);


### PR DESCRIPTION
Rename "Relation" to "Reference".

Add optional flag to schema values. This is not super pretty because it should probably only be allowed on objects, not primitives/arrays.

Still this allows us to continue while being backwards-compatible.

Suggestions welcome.