### PR TITLE
Add hello wall specific fire rating

### DIFF
--- a/examples/Hello Wall/hello-wall-add-specific-fire-rating.ifcx
+++ b/examples/Hello Wall/hello-wall-add-specific-fire-rating.ifcx
@@ -1,0 +1,33 @@
+{
+  "header": {
+    "id": "ifc5.technical.buildingsmart.org/examples/Hello Wall/hello-wall-add-fire-rating-60@v1.ifcx",
+    "version": "ifcx_alpha",
+    "author": "authorname",
+    "timestamp": "time string"
+  },
+  "imports": [],
+  "schemas": {
+    "bsi::ifc::v5a::prop::firerating": {
+      "value": {
+          "dataType": "Enum",
+          "enumRestrictions": {
+            "options": ["R30", "R60"]
+          }
+      }
+    }
+  },
+  "data": [
+    {
+      "path":"25503984-6605-43a1-8597-eae657ff5bea",
+      "attributes": {
+        "bsi::ifc::v5a::prop::firerating": "R30"
+      }
+    },
+    {
+      "path":"ab143723-f7b1-5368-b106-55896e88d768/My_Project/My_Site/My_Building/My_Storey/Wall/Window_001",
+      "attributes": {
+        "bsi::ifc::v5a::prop::firerating": "R60"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Re-add a specific fire rating example

- `25503984-6605-43a1-8597-eae657ff5bea` (window type) `"bsi::ifc::v5a::prop::firerating": "R30"`
- `ab143723-f7b1-5368-b106-55896e88d768/My_Project/My_Site/My_Building/My_Storey/Wall/Window_001` `"bsi::ifc::v5a::prop::firerating": "R60"`