### PR TITLE
Fix validation crash on Array schemas without arrayRestrictions

### DIFF
--- a/src/ifcx-core/schema/schema-validation.ts
+++ b/src/ifcx-core/schema/schema-validation.ts
@@ -107,6 +107,10 @@ function ValidateAttributeValue(desc: IfcxValueDescription, value: any, path: st
         {
             throw new SchemaValidationError(`Expected "${value}" to be of type array`);
         }
+        if (!desc.arrayRestrictions)
+        {
+            throw new SchemaValidationError(`Expected arrayRestrictions to be present on a schema of dataType "Array"`);
+        }
         value.forEach((entry) => {
             ValidateAttributeValue(desc.arrayRestrictions!.value, entry, path + ".<array>.", schemas);
         })

--- a/src/test/schema-test.ts
+++ b/src/test/schema-test.ts
@@ -49,4 +49,18 @@ describe("schemas", () => {
         expect(() => LoadIfcxFile(ExampleFile("example::array", []))).to.not.throw(SchemaValidationError);
         expect(() => LoadIfcxFile(ExampleFile("example::array", ["a"]))).to.not.throw(SchemaValidationError);
     });
+
+    it("rejects an Array schema without arrayRestrictions, as a SchemaValidationError", () => {
+        // A bare "Array" is not a sufficient definition — the element type must be
+        // qualified. arrayRestrictions is optional in ifcx.tsp only because dataType cannot
+        // act as a discriminator there, so the validator has to enforce it.
+        // Previously this threw a raw TypeError from dereferencing
+        // desc.arrayRestrictions!.value, which named neither the node nor the schema.
+        expect(() => LoadIfcxFile(ExampleFileWithSchema("Array", []))).to.throw(SchemaValidationError);
+        expect(() => LoadIfcxFile(ExampleFileWithSchema("Array", ["a"]))).to.throw(SchemaValidationError);
+        // and specifically NOT a bare TypeError
+        expect(() => LoadIfcxFile(ExampleFileWithSchema("Array", ["a"]))).to.not.throw(TypeError);
+        // a well-formed Array schema is unaffected
+        expect(() => LoadIfcxFile(ExampleFile("example::array", ["a"]))).to.not.throw();
+    });
 });


### PR DESCRIPTION
Fixes #137.

## Problem

A bare `{"dataType": "Array"}` schema made the validator throw a raw

```
TypeError: Cannot read properties of undefined (reading 'value')
```

because the `Array` branch of `ValidateAttributeValue` dereferenced
`desc.arrayRestrictions!` unconditionally.

## Change

Per review on #137: a bare `"Array"` is not a sufficient definition — the element type has
to be qualified. `arrayRestrictions` is optional in `schema/ifcx.tsp:69` only because
`dataType` cannot act as a discriminator there to make the structural fields conditionally
mandatory, so the validator is the only place the requirement can be expressed.

It now rejects the schema explicitly. The error routes through the existing wrapper in
`Validate`, so it names both the node path and the schema id:

```
SchemaValidationError: Error validating ["root"].attributes["test::tags"]:
Expected arrayRestrictions to be present on a schema of dataType "Array"
```

which is what the `TypeError` failed to do — it carried neither, so there was nothing to
trace back to the responsible schema entry.

## Compatibility

Nothing that validates today starts failing: there are **no** `dataType: "Array"` schemas in
`examples/`, in `schema/`, or in the published `core` / `prop@v5a` documents.

## Test

Adds one regression test in `src/test/schema-test.ts`, using the existing
`ExampleFileWithSchema` helper — which already builds a single-schema file with no
restrictions — so **no fixtures change** and no other test's expectations move. It asserts
the rejection, that it is not a bare `TypeError`, and that a well-formed Array schema is
unaffected.

Verified the test fails with the change reverted (and only that test fails). Suite: 29
passing, 0 failing.

## Note

Reworked from the permissive reading (tolerate the absence) after review. Happy to switch
back if @tomvandig reads the spec the other way — it is a one-line difference.
